### PR TITLE
Add script to compute additional metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,35 @@ This repo contains all the code related to my **Master Thesis Research**. The **
 ## Architecture
 <img src="images/gsum.png" width="40%" height="40%" alt="Architecture" title="Architecture">
 
-#### Main Commands to operate:
 
-##### Plain BART
+## Getting Started
+
+This repository uses Python 3.9.
+Download [requirements.txt](requirements.txt) and install all dependencies with following command : 
+
+```bash
+pip install -r requirements.txt
+```
+
+If you want to compute ROUGE, BERTScore, METEOR and BLANC with `compute_metrics.py`, you need to install the following packages:
+
+```bash
+pip install evaluate blanc==0.3.4 bert-score==0.3.13 rouge_score==0.1.2
+```
+
+## Preparation
+In order to train E-BART, we need to provide event based guidance signals.
+1. We do this by training a model for Event Detection on the MAVEN-ED dataset and predicting events for the NarraSum dataset: https://github.com/leonhardhennig/MAVEN-dataset/tree/debug/baselines/BERT%2BCRF/BERT-CRF-MAVEN
+2. We prepare the augmented NarraSum dataset for Event Relation Extraction.
+3. We then train a model for Event Relation Extraction on the MAVEN-ERE dataset and predict event relations for the event augmented NarraSum dataset: https://github.com/phucdev/MAVEN-ERE/tree/main/joint
+4. We apply filtering to the augmented NarraSum dataset and convert the predicted events and event relations to guidance signals.
+
+
+## Training and Evaluation
+Keep in mind that you have to adjust all the paths to your own paths.
+In order to track the training with `wandb` you need to log in with `wandb login` before running the scripts.
+
+### Plain BART
 
 ```bash
 python run_summarization.py \
@@ -19,10 +45,10 @@ python run_summarization.py \
     --do_train \
     --do_eval \
     --do_predict \
-    --train_file /ds/other/GS6/train.json \
-    --validation_file /ds/other/GS6/valid.json \
-    --test_file /ds/other/GS6/test.json \
-    --output_dir /netscratch/truong/eventsum/E-BART/NarraSum_model/output/baseline \
+    --train_file PATH/TO/YOUR/train.json \
+    --validation_file PATH/TO/YOUR/valid.json \
+    --test_file PATH/TO/YOUR/test.json \
+    --output_dir PATH/TO/YOUR/E-BART/NarraSum_model/output/baseline \
     --per_device_train_batch_size=8 \
     --per_device_eval_batch_size=8 \
     --overwrite_output_dir \
@@ -41,43 +67,21 @@ python run_summarization.py \
     --max_eval_samples 300
 ```
 
-#### GSum
-
-Original:
-```bash
-python train.py \
-    --train_file /ds/other/NarraSum/NarraSum/train.json 
-    --val_file /ds/other/NarraSum/NarraSum/validation.json 
-    --test_file /ds/other/NarraSum/NarraSum/test.json 
-    --train_guidance /ds/other/GS1_guid/train.json 
-    --val_guidance /ds/other/GS1_guid/validation.json 
-    --test_guidance /ds/other/GS1_guid/test.json 
-    --per_device_train_batch_size 4 
-    --output_dir /netscratch/gillet/projects/E-BART/output/GS1 
-    --max_eval_samples 300 
-    --learning_rate 0.000003 
-    --per_device_eval_batch_size 4 
-    --max_target_length 250 
-    --load_best_model_at_end True 
-    --num_train_epochs 3 
-    --evaluation_strategy steps 
-    --predict_with_generate 
-    --metric_for_best_model rouge1
-```
+### GSum
 
 ```bash 
 python e_bart/train.py \
-    --train_file /ds/other/GS6/train.json \
-    --val_file /ds/other/GS6/valid.json \
-    --test_file /ds/other/GS6/test.json \
-    --train_guidance /ds/other/GS6_guid/train.json \
-    --val_guidance /ds/other/GS6_guid/valid.json \
-    --test_guidance /ds/other/GS6_guid/test.json \
+    --train_file PATH/TO/YOUR/train.json \
+    --val_file PATH/TO/YOUR/valid.json \
+    --test_file PATH/TO/YOUR/test.json \
+    --train_guidance PATH/TO/YOUR/train_guidance.json \
+    --val_guidance PATH/TO/YOUR/valid_guidance.json \
+    --test_guidance PATH/TO/YOUR/test_guidance.json \
     --per_device_train_batch_size 4 \
     --gradient_accumulation_steps 2 \
-    --output_dir /netscratch/truong/eventsum/E-BART/NarraSum_model/output/e-bart \
+    --output_dir PATH/TO/YOUR/E-BART/NarraSum_model/output/e-bart \
     --max_eval_samples 300 \
-    --pretrained_weights /netscratch/truong/eventsum/E-BART/model.bin \
+    --pretrained_weights PATH/TO/YOUR/E-BART/model.bin \
     --learning_rate 0.000003 \
     --per_device_eval_batch_size 4 \
     --max_target_length 250 \
@@ -89,14 +93,19 @@ python e_bart/train.py \
     --metric_for_best_model rouge1
 ```
 
-#### Python Requirements
+## Compute additional metrics
 
-This repository uses Python 3.9.
-Download [requirements.txt](requirements.txt) and install all dependencies with following command : 
+The training scripts will compute ROUGE scores during the evaluation and export the predicted summaries along with the 
+original documents and reference summaries in a file called `generated_predictions.jsonl`.
+In order to compute additional metrics (BERTScore, METEOR, BLANC), you can use the `compute_metrics.py` script:
 
 ```bash
-pip install -r requirements.txt
+python compute_metrics.py \
+    --predictions_file PATH/TO/YOUR/E-BART/NarraSum_model/output/e-bart/generated_predictions.jsonl \
+    --output_file PATH/TO/YOUR/E-BART/NarraSum_model/output/e-bart/predictions_metrics.json \
+    --postprocess
 ```
+The `--postprocess` will do some processing for ROUGE evaluation because rougeLSum expects newline after each sentence.
 
 ## Datasets
 - [NarraSum](https://github.com/zhaochaocs/narrasum)

--- a/compute_metrics.py
+++ b/compute_metrics.py
@@ -76,7 +76,7 @@ def main():
 
     bert_score = evaluate.load("bertscore")
     bert_scores = bert_score.compute(predictions=predictions, references=references, lang="en")
-    result_dict.update(bert_scores)
+    result_dict["bert_score"] = bert_scores
     logger.info(f"BERTScore scores:\n{bert_scores}")
 
     blanc = evaluate.load("phucdev/blanc_score")

--- a/compute_metrics.py
+++ b/compute_metrics.py
@@ -18,6 +18,7 @@ def parse_args():
     parser.add_argument("--predictions_file", type=str, help="Path to the predictions JSONL file")
     parser.add_argument("--output_file", type=str, help="Path to the output file")
     parser.add_argument("--postprocess", action="store_true", default=False, help="Whether to postprocess the text")
+    parser.add_argument("--inference_batch_size", type=int, default=128, help="Inference batch size for BLANC")
     return parser.parse_args()
 
 

--- a/compute_metrics.py
+++ b/compute_metrics.py
@@ -1,0 +1,98 @@
+import evaluate
+import argparse
+import json
+import nltk
+import torch
+import logging
+
+from filelock import FileLock
+
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Compute metrics for a predictions file")
+    parser.add_argument("--predictions_file", type=str, help="Path to the predictions JSONL file")
+    parser.add_argument("--output_file", type=str, help="Path to the output file")
+    parser.add_argument("--postprocess", action="store_true", default=False, help="Whether to postprocess the text")
+    return parser.parse_args()
+
+
+def postprocess_text(preds, labels):
+    preds = [pred.strip() for pred in preds]
+    labels = [label.strip() for label in labels]
+
+    # rougeLSum expects newline after each sentence
+    preds = ["\n".join(nltk.sent_tokenize(pred)) for pred in preds]
+    labels = ["\n".join(nltk.sent_tokenize(label)) for label in labels]
+
+    return preds, labels
+
+
+def main():
+    args = parse_args()
+    try:
+        nltk.data.find("tokenizers/punkt")
+    except (LookupError, OSError):
+        with FileLock(".lock") as lock:
+            nltk.download("punkt", quiet=True)
+    try:
+        nltk.data.find("tokenizers/punkt_tab")
+    except (LookupError, OSError):
+        with FileLock(".lock") as lock:
+            nltk.download("punkt_tab", quiet=True)
+
+    logger.info(f"Reading predictions file from {args.predictions_file}...")
+    predictions = []
+    references = []
+    documents = []
+    with open(args.predictions_file, mode="r") as f:
+        for line in f:
+            example = json.loads(line)
+            predictions.append(example["generated_prediction"])
+            references.append(example["summary"])
+            documents.append(example["document"])
+
+    logger.info("Computing metrics...")
+
+    rouge = evaluate.load("rouge")
+    if args.postprocess:
+        # Relevant for rougeLSum
+        rouge_predictions, rouge_references = postprocess_text(predictions, references)
+        rouge_scores = rouge.compute(predictions=rouge_predictions, references=rouge_references, use_stemmer=True)
+    else:
+        rouge_scores = rouge.compute(predictions=predictions, references=references, use_stemmer=True)
+    result_dict = {k: round(v * 100, 4) for k, v in rouge_scores.items()}
+    logger.info(f"ROUGE scores:\n{result_dict}")
+
+    meteor = evaluate.load("meteor")
+    meteor_scores = meteor.compute(predictions=predictions, references=references)
+    result_dict.update(meteor_scores)
+    logger.info(f"METEOR score:\n{meteor_scores}")
+
+    bert_score = evaluate.load("bertscore")
+    bert_scores = bert_score.compute(predictions=predictions, references=references, lang="en")
+    result_dict.update(bert_scores)
+    logger.info(f"BERTScore scores:\n{bert_scores}")
+
+    blanc = evaluate.load("phucdev/blanc_score")
+    blanc_scores = blanc.compute(
+        summaries=predictions,
+        documents=documents,
+        blanc_score="help",
+        device="cuda" if torch.cuda.is_available() else "cpu",
+        inference_batch_size=128
+    )
+    result_dict.update(blanc_scores)
+    logger.info(f"BLANC scores:\n{blanc_scores}")
+
+    with open(args.output_file, mode="w") as out_f:
+        out_f.write(json.dumps(result_dict, indent=2))
+    logger.info(f"Metrics saved to {args.output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_summarization.py
+++ b/run_summarization.py
@@ -709,6 +709,7 @@ def main():
         trainer.log_metrics("eval", metrics)
         trainer.save_metrics("eval", metrics)
 
+    # Prediction
     if training_args.do_predict:
         logger.info("*** Predict ***")
 


### PR DESCRIPTION
The training scripts produce a `generated_predictions.jsonl` file that contains the predicted summaries along with the documents and reference summaries.
I added a `compute_metrics.py` script that takes this file and computes ROUGE, METEOR, BERTScore and BLANC-help.

ROUGE, METEOR and BERTScore already exist in https://huggingface.co/evaluate-metric.
For BLANC I added a Hugging Face Space so we can also load it via `evaluate`: https://huggingface.co/spaces/phucdev/blanc_score

BLANC is a reference-free metric. It does not require a reference summary. Instead it measures how much a summary helps a pre-trained language model (like BERT) perform a language understanding task, such as filling in masked words in a document.
There are two variants of BLANC. We use BLANC-help. The summary is concatenated with document sentences during the inference task. The BLANC-help score is defined as the difference in accuracy between unmasking tokens with the summary and with filler text (same length as the summary but consisting of period symbols). It measures how much the summary boosts the model’s performance on masked tokens.

I also updated the README.md with more instructions. 